### PR TITLE
Remove thread leak when stopping river

### DIFF
--- a/src/main/java/org/elasticsearch/river/wikipedia/support/WikiXMLParser.java
+++ b/src/main/java/org/elasticsearch/river/wikipedia/support/WikiXMLParser.java
@@ -23,6 +23,7 @@ import org.elasticsearch.river.wikipedia.bzip2.CBZip2InputStream;
 import org.xml.sax.InputSource;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -36,6 +37,7 @@ public abstract class WikiXMLParser {
 
     private URL wikiXMLFile = null;
     protected WikiPage currentPage = null;
+    private BufferedReader br;
 
     public WikiXMLParser(URL fileName) {
         wikiXMLFile = fileName;
@@ -69,15 +71,14 @@ public abstract class WikiXMLParser {
      * @throws Exception
      */
     protected InputSource getInputSource() throws Exception {
-        BufferedReader br = null;
-
         if (wikiXMLFile.toExternalForm().endsWith(".gz")) {
             br = new BufferedReader(new InputStreamReader(new GZIPInputStream(wikiXMLFile.openStream()), "UTF-8"));
         } else if (wikiXMLFile.toExternalForm().endsWith(".bz2")) {
             InputStream fis = wikiXMLFile.openStream();
             byte[] ignoreBytes = new byte[2];
             fis.read(ignoreBytes); //"B", "Z" bytes from commandline tools
-            br = new BufferedReader(new InputStreamReader(new CBZip2InputStream(fis), "UTF-8"));
+            CBZip2InputStream cbZip2InputStream = new CBZip2InputStream(fis);
+            br = new BufferedReader(new InputStreamReader(cbZip2InputStream, "UTF-8"));
         } else {
             br = new BufferedReader(new InputStreamReader(wikiXMLFile.openStream(), "UTF-8"));
         }
@@ -87,6 +88,11 @@ public abstract class WikiXMLParser {
 
     protected void notifyPage(WikiPage page) {
         currentPage = page;
+    }
 
+    public void close() throws IOException {
+        if (br != null) {
+            br.close();
+        }
     }
 }


### PR DESCRIPTION
Caught by integration tests, we could have thread leaks when closing river:

```
   >    2) Thread[id=228, name=elasticsearch[node_s3][wikipedia_slurper][T#1], state=RUNNABLE, group=TGRP-WikipediaRiverTest]
   >         at java.net.SocketInputStream.socketRead0(Native Method)
   >         at java.net.SocketInputStream.read(SocketInputStream.java:152)
   >         at java.net.SocketInputStream.read(SocketInputStream.java:122)
   >         at java.io.BufferedInputStream.fill(BufferedInputStream.java:235)
   >         at java.io.BufferedInputStream.read1(BufferedInputStream.java:275)
   >         at java.io.BufferedInputStream.read(BufferedInputStream.java:334)
   >         at sun.net.www.MeteredStream.read(MeteredStream.java:134)
   >         at java.io.FilterInputStream.read(FilterInputStream.java:133)
   >         at sun.net.www.protocol.http.HttpURLConnection$HttpInputStream.read(HttpURLConnection.java:3053)
   >         at sun.net.www.protocol.http.HttpURLConnection$HttpInputStream.read(HttpURLConnection.java:3047)
   >         at sun.net.www.protocol.http.HttpURLConnection$HttpInputStream.read(HttpURLConnection.java:3035)
   >         at org.elasticsearch.river.wikipedia.bzip2.CBZip2InputStream.getAndMoveToFrontDecode(CBZip2InputStream.java:693)
   >         at org.elasticsearch.river.wikipedia.bzip2.CBZip2InputStream.initBlock(CBZip2InputStream.java:282)
   >         at org.elasticsearch.river.wikipedia.bzip2.CBZip2InputStream.setupNoRandPartA(CBZip2InputStream.java:839)
   >         at org.elasticsearch.river.wikipedia.bzip2.CBZip2InputStream.setupNoRandPartB(CBZip2InputStream.java:888)
   >         at org.elasticsearch.river.wikipedia.bzip2.CBZip2InputStream.read0(CBZip2InputStream.java:205)
   >         at org.elasticsearch.river.wikipedia.bzip2.CBZip2InputStream.read(CBZip2InputStream.java:173)
   >         at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:283)
   >         at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:325)
   >         at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:177)
   >         at java.io.InputStreamReader.read(InputStreamReader.java:184)
   >         at java.io.BufferedReader.read1(BufferedReader.java:203)
   >         at java.io.BufferedReader.read(BufferedReader.java:279)
   >         at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.load(XMLEntityScanner.java:1753)
   >         at com.sun.org.apache.xerces.internal.impl.XMLEntityScanner.skipChar(XMLEntityScanner.java:1426)
   >         at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2807)
   >         at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:606)
   >         at com.sun.org.apache.xerces.internal.impl.XMLNSDocumentScannerImpl.next(XMLNSDocumentScannerImpl.java:117)
   >         at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:510)
   >         at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:848)
   >         at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:777)
   >         at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
   >         at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
   >         at org.elasticsearch.river.wikipedia.support.WikiXMLSAXParser.parse(WikiXMLSAXParser.java:68)
   >         at org.elasticsearch.river.wikipedia.WikipediaRiver$Parser.run(WikipediaRiver.java:192)
   >         at java.lang.Thread.run(Thread.java:745)
```

CBZip2InputStream is never closed.